### PR TITLE
feature: add new server:list command

### DIFF
--- a/app/Commands/ListServersCommand.php
+++ b/app/Commands/ListServersCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Commands;
+
+use App\Concerns\EnsureHasToken;
+use App\Support\Ploi;
+use LaravelZero\Framework\Commands\Command;
+
+class ListServersCommand extends Command
+{
+    use EnsureHasToken;
+
+    protected $signature = 'server:list';
+
+    protected $description = 'Prints a list of all servers';
+
+    public function handle(Ploi $ploi)
+    {
+        $this->ensureHasToken();
+
+        $servers = $ploi->getServers();
+
+        $this->table([
+            'ID',
+            'Type',
+            'Name',
+            'IP Address',
+            'Number of Sites',
+            'Status'
+        ], collect($servers)->map(function ($server) {
+            return [
+                'id' => $server['id'],
+                'type' => $server['type'],
+                'name' => $server['name'],
+                'ip_address' => $server['ip_address'],
+                'number_of_sites' => $server['sites_count'],
+                'status' => $server['status'],
+            ];
+        }));
+    }
+}


### PR DESCRIPTION
This pull request adds a new `server:list` command.

This will output some basic information about the servers present on the account.