### PR TITLE
feature: add new ssh command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.vscode
 /.vagrant
 .phpunit.result.cache
+ploi.yml

--- a/app/Commands/SshCommand.php
+++ b/app/Commands/SshCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Commands;
+
+use App\Concerns\EnsureHasPloiConfiguration;
+use App\Concerns\EnsureHasToken;
+use App\Support\Configuration;
+use App\Support\Ploi;
+use Illuminate\Console\Scheduling\Schedule;
+use LaravelZero\Framework\Commands\Command;
+
+class SshCommand extends Command
+{
+    use EnsureHasToken;
+    use EnsureHasPloiConfiguration;
+
+    protected $signature = 'ssh {user?}';
+
+    protected $description = 'Start a new SSH session.';
+
+    public function handle(Ploi $ploi, Configuration $configuration)
+    {
+        $this->ensureHasToken();
+        $this->ensureHasPloiConfiguration();
+
+        $server = $ploi->getServer($configuration->get('server'));
+        $site = $ploi->getSite($configuration->get('server'), $configuration->get('site'));
+        $user = $this->argument('user') ?? 'ploi';
+
+        $this->info('Establishing SSH connection...');
+
+        passthru($this->buildCommand($server, $site, $user));
+    }
+
+    protected function buildCommand($server, $site, $user)
+    {
+        return sprintf('ssh -t %s@%s "cd %s; bash --login"', $user, $server['ip_address'], $site['domain'] . $site['project_root']);
+    }
+}

--- a/app/Support/Ploi.php
+++ b/app/Support/Ploi.php
@@ -27,6 +27,11 @@ class Ploi
         return $response['data'];
     }
 
+    public function getServer($server)
+    {
+        return Http::withToken($this->token)->get(self::$BASE_URL . "servers/{$server}")['data'];
+    }
+
     public function getServerProviders()
     {
         return Http::withToken($this->token)->get(self::$BASE_URL . "user/server-providers")['data'];
@@ -35,6 +40,11 @@ class Ploi
     public function getSites($server)
     {
         return Http::withToken($this->token)->get(self::$BASE_URL . "servers/{$server}/sites?per_page=50")['data'];
+    }
+
+    public function getSite($server, $site)
+    {
+        return Http::withToken($this->token)->get(self::$BASE_URL . "servers/{$server}/sites/{$site}")['data'];
     }
 
     public function createSite($server, $rootDomain, $webDir, $systemUser): int


### PR DESCRIPTION
This pull request introduces a new `ssh` command that will open up an SSH session on the configured server and also `cd` into the site's directory.

I plan on making pull requests to configure SSH keys too, so for now it will assume you have an SSH key configured with Ploi and the server already.